### PR TITLE
From cmssw 12 4 0 pre4

### DIFF
--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -565,7 +565,7 @@ void ZCounting::analyzeMuons(const edm::Event& iEvent, const edm::EventSetup& iS
         continue;
 
       bool isTrackCentral = false;
-      if (fabs(eta2) > MUON_BOUND)
+      if (fabs(eta2) < MUON_BOUND)
         isTrackCentral = true;
 
       if (itTrk.hitPattern().trackerLayersWithMeasurement() >= 6 && itTrk.hitPattern().numberOfValidPixelHits() >= 1) {

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -865,7 +865,20 @@ bool ZCounting::isMuonTriggerObj(const ZCountingTrigger::TTrigger& triggerMenu, 
 }
 
 //--------------------------------------------------------------------------------------------------
-// To build a new function
+// Definition of the CustomTightID function
+bool ZCounting::isCustomTightMuon(const reco::Muon& muon) {
+
+if(!muon.isPFMuon() || !muon.isGlobalMuon() ) return false;
+
+bool muID = isGoodMuon(muon,muon::GlobalMuonPromptTight) && (muon.numberOfMatchedStations() > 1);
+    
+  
+bool hits = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
+  muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0; 
+
+
+return muID && hits;
+}
 
 //--------------------------------------------------------------------------------------------------
 bool ZCounting::passMuonID(
@@ -878,6 +891,8 @@ bool ZCounting::passMuonID(
   else if (idType == MediumID && muon::isMediumMuon(muon))
     return true;
   else if (idType == TightID && muon::isTightMuon(muon, vtx))
+    return true;
+  else if(idType == CustomTightID && isCustomTightMuon(muon))    
     return true;
   else if (idType == NoneID)
     return true;

--- a/DQMOffline/Lumi/plugins/ZCounting.cc
+++ b/DQMOffline/Lumi/plugins/ZCounting.cc
@@ -609,8 +609,8 @@ void ZCounting::analyzeElectrons(const edm::Event& iEvent, const edm::EventSetup
   }
 
   // Good vertex requirement
-  if (nvtx == 0)
-    return;
+  //if (nvtx == 0)
+  //  return;
 
   //-------------------------------
   //--- Trigger

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -43,7 +43,7 @@ public:
   ZCounting(const edm::ParameterSet& ps);
   ~ZCounting() override;
 
-  enum MuonIDTypes { NoneID, LooseID, MediumID, TightID };
+  enum MuonIDTypes { NoneID, LooseID, MediumID, TightID, CustomTightID };
   enum MuonIsoTypes { NoneIso, TrackerIso, PFIso };
 
 protected:
@@ -59,6 +59,7 @@ private:
   bool isMuonTriggerObj(const ZCountingTrigger::TTrigger& triggerMenu, const TriggerObjects& hltMatchBits);
   bool passMuonID(const reco::Muon& muon, const reco::Vertex& vtx, const MuonIDTypes& idType);
   bool passMuonIso(const reco::Muon& muon, const MuonIsoTypes& isoType, const float isoCut);
+  bool isCustomTightMuon(const reco::&Muon muon);
 
   // Electron-specific functions
   bool isElectronTrigger(ZCountingTrigger::TTrigger triggerMenu, TriggerBits hltBits);

--- a/DQMOffline/Lumi/plugins/ZCounting.h
+++ b/DQMOffline/Lumi/plugins/ZCounting.h
@@ -59,7 +59,7 @@ private:
   bool isMuonTriggerObj(const ZCountingTrigger::TTrigger& triggerMenu, const TriggerObjects& hltMatchBits);
   bool passMuonID(const reco::Muon& muon, const reco::Vertex& vtx, const MuonIDTypes& idType);
   bool passMuonIso(const reco::Muon& muon, const MuonIsoTypes& isoType, const float isoCut);
-  bool isCustomTightMuon(const reco::&Muon muon);
+  bool isCustomTightMuon(const reco::Muon& muon);
 
   // Electron-specific functions
   bool isElectronTrigger(ZCountingTrigger::TTrigger triggerMenu, TriggerBits hltBits);

--- a/DQMOffline/Lumi/python/ZCounting_cff.py
+++ b/DQMOffline/Lumi/python/ZCounting_cff.py
@@ -17,15 +17,15 @@ zcounting = DQMEDAnalyzer('ZCounting',
                                  beamspotName = cms.InputTag('offlineBeamSpot'),
                                  conversionsName = cms.InputTag('conversions'),
 
-                                 MuonTriggerNames = cms.vstring("HLT_IsoMu27_v*"),
-                                 MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sMu22Or25L1f0L2f10QL3f27QL3trkIsoFiltered0p07"),
+                                 MuonTriggerNames = cms.vstring("HLT_IsoMu24_v*"),
+                                 MuonTriggerObjectNames = cms.vstring("hltL3crIsoL1sSingleMu22L1f0L2f10QL3f24QL3trkIsoFiltered0p07"),
 
-                                 IDType   = cms.untracked.string("Tight"),# Tight, Medium, Loose
+                                 IDType   = cms.untracked.string("CustomTight"),# Tight, Medium, Loose, CustomTight
                                  IsoType  = cms.untracked.string("NULL"),  # Tracker-based, PF-based
                                  IsoCut   = cms.untracked.double(0.),     # {0.05, 0.10} for Tracker-based, {0.15, 0.25} for PF-based
 
-                                 PtCutL1  = cms.untracked.double(30.0),
-                                 PtCutL2  = cms.untracked.double(30.0),
+                                 PtCutL1  = cms.untracked.double(27.0),
+                                 PtCutL2  = cms.untracked.double(27.0),
                                  EtaCutL1 = cms.untracked.double(2.4),
                                  EtaCutL2 = cms.untracked.double(2.4),
 
@@ -38,17 +38,17 @@ zcounting = DQMEDAnalyzer('ZCounting',
 
                                  ElectronIDType = cms.untracked.string("TIGHT"),
 
-                                 MassBin  = cms.untracked.int32(50),
-                                 MassMin  = cms.untracked.double(66.0),
-                                 MassMax  = cms.untracked.double(116.0),
+                                 MassBin  = cms.untracked.int32(80),
+                                 MassMin  = cms.untracked.double(50.0),
+                                 MassMax  = cms.untracked.double(130.0),
 
                                  LumiBin  = cms.untracked.int32(2500),
                                  LumiMin  = cms.untracked.double(0.5),
                                  LumiMax  = cms.untracked.double(2500.5),
 
-                                 PVBin    = cms.untracked.int32(60),
+                                 PVBin    = cms.untracked.int32(100),
                                  PVMin    = cms.untracked.double(0.5),
-                                 PVMax    = cms.untracked.double(60.5),
+                                 PVMax    = cms.untracked.double(100.5),
 
                                  VtxNTracksFitMin = cms.untracked.double(0.),
                                  VtxNdofMin       = cms.untracked.double(4.),


### PR DESCRIPTION
PR description:

At the python file there are some modifications in the values for pT, mass range and PU and the change of the trigger (from HLT_IsoMu_27 to HLT_IsoMu_24), concerning the preparation for Run3.

The definition of a Custom Tight ID for the muon, with no consideration of the primary vertices. Also a bug fixing. 


PR validation:

Compilation of the cmssw and a test using the test/[ZCounting_cfg.py](https://github.com/ThOliveira23/cmssw/blob/from-CMSSW_10_6_30_v3/DQMOffline/Lumi/test/ZCounting_cfg.py) to produce the root file.


if this PR is a backport please specify the original PR and why you need to backport that PR:

There isn’t a backport intended.